### PR TITLE
Fix osx ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: ${{ matrix.python }}
     - name: Install Dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools wheel
         pip install pipenv
         pipenv install --dev --skip-lock --python=${{ matrix.python }}
     - name: Run tests


### PR DESCRIPTION
CI Started failing to install black because of missing setuptools / wheel.
No changes were made. To add to the weirdness, compcorrector has the same step in CI (osx-latest, python 3.6, install black) and runs fine. Only difference is matrix here to use 3.7 too.

Passing build 26: https://github.com/ConorSheehan1/caesar_cipher/actions/runs/82418466
Failing build 27: https://github.com/ConorSheehan1/caesar_cipher/actions/runs/88596863